### PR TITLE
[#10] MemberEntity 정적 팩토리 메서드에서 Builder로 변경

### DIFF
--- a/src/main/java/com/domo/ecommerce/common/entity/BaseEntity.java
+++ b/src/main/java/com/domo/ecommerce/common/entity/BaseEntity.java
@@ -3,18 +3,22 @@ package com.domo.ecommerce.common.entity;
 import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-@Setter
 public class BaseEntity {
-    private Boolean isDeleted;
-    // 회원가입일
+    @CreatedDate
     private LocalDateTime createdAt;
-    // 최종 수정일
+
+    @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    @NotNull
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/domo/ecommerce/entity/Member.java
+++ b/src/main/java/com/domo/ecommerce/entity/Member.java
@@ -24,6 +24,7 @@ import org.hibernate.annotations.Where;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 @Where(clause = "deleted_at is null")
 @SQLDelete(sql = "UPDATE member SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 public class Member extends BaseEntity {

--- a/src/main/java/com/domo/ecommerce/entity/Member.java
+++ b/src/main/java/com/domo/ecommerce/entity/Member.java
@@ -11,63 +11,66 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted_at is null")
+@SQLDelete(sql = "UPDATE member SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 public class Member extends BaseEntity {
-    protected Member() {
-
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //회원 아이디
+    @NotNull //회원 아이디
     private String memberId;
 
-    //회원 패스워드
+    @NotNull //회원 패스워드
     private String password;
 
-    //회원 이름
+    @NotNull //회원 이름
     private String name;
 
-    //회원 전화번호
+    @NotNull //회원 전화번호
     private String tel;
 
-    //회원 상태
+    @NotNull //회원 상태
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
-    //회원 권한
+    @NotNull //회원 권한
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    //우편번호
+    @NotNull //우편번호
     private String addressCode;
 
-    //주소
+    @NotNull //주소
     private String address;
 
-    //상세주소
+    @NotNull //상세주소
     private String addressDetail;
 
-
-    public static Member signUp(String memberId, String password, String name, String tel,
-            String addressCode, String address, String addressDetail) {
-        Member member = new Member();
-        member.memberId = memberId;
-        member.password = SHA256Util.encryptSHA256(password);
-        member.name = name;
-        member.tel = tel;
-        member.status = MemberStatus.DEFAULT;
-        member.role = Role.MEMBER;
-        member.addressCode = addressCode;
-        member.address = address;
-        member.addressDetail = addressDetail;
-        member.setCreatedAt(LocalDateTime.now());
-        member.setIsDeleted(false);
-        return member;
+    @Builder
+    public Member(Long id, String memberId, String password, String name, String tel,
+            MemberStatus status, Role role, String addressCode, String address,
+            String addressDetail) {
+        this.id = id;
+        this.memberId = memberId;
+        this.password = password;
+        this.name = name;
+        this.tel = tel;
+        this.status = status;
+        this.role = role;
+        this.addressCode = addressCode;
+        this.address = address;
+        this.addressDetail = addressDetail;
     }
 }

--- a/src/main/java/com/domo/ecommerce/entity/Member.java
+++ b/src/main/java/com/domo/ecommerce/entity/Member.java
@@ -13,6 +13,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +23,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Where(clause = "deleted_at is null")
 @SQLDelete(sql = "UPDATE member SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 public class Member extends BaseEntity {
@@ -57,20 +59,4 @@ public class Member extends BaseEntity {
 
     @NotNull //상세주소
     private String addressDetail;
-
-    @Builder
-    public Member(Long id, String memberId, String password, String name, String tel,
-            MemberStatus status, Role role, String addressCode, String address,
-            String addressDetail) {
-        this.id = id;
-        this.memberId = memberId;
-        this.password = password;
-        this.name = name;
-        this.tel = tel;
-        this.status = status;
-        this.role = role;
-        this.addressCode = addressCode;
-        this.address = address;
-        this.addressDetail = addressDetail;
-    }
 }

--- a/src/main/java/com/domo/ecommerce/service/MemberService.java
+++ b/src/main/java/com/domo/ecommerce/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.domo.ecommerce.service;
 
+import static com.domo.ecommerce.type.MemberStatus.DEFAULT;
 import static com.domo.ecommerce.type.MemberStatus.DELETED;
+import static com.domo.ecommerce.type.Role.MEMBER;
 
 import com.domo.ecommerce.entity.Member;
 import com.domo.ecommerce.exception.DuplicateMemberIdException;
@@ -32,7 +34,17 @@ public class MemberService {
         isDuplicatedMemberId(memberId);
 
         memberRepository.save(
-                Member.signUp(memberId, password, name, tel, addressCode, address, addressDetail)
+                Member.builder()
+                        .memberId(memberId)
+                        .password(SHA256Util.encryptSHA256(password))
+                        .name(name)
+                        .tel(tel)
+                        .addressCode(addressCode)
+                        .address(address)
+                        .addressDetail(addressDetail)
+                        .status(DEFAULT)
+                        .role(MEMBER)
+                        .build()
         );
     }
 

--- a/src/main/java/com/domo/ecommerce/service/MemberService.java
+++ b/src/main/java/com/domo/ecommerce/service/MemberService.java
@@ -34,8 +34,17 @@ public class MemberService {
         isDuplicatedMemberId(memberId);
 
         memberRepository.save(
-                new Member(null, memberId, SHA256Util.encryptSHA256(password), name,
-                        tel, DEFAULT, MEMBER, addressCode, address, addressDetail));
+                Member.builder()
+                        .memberId(memberId)
+                        .password(SHA256Util.encryptSHA256(password))
+                        .name(name)
+                        .tel(tel)
+                        .status(DEFAULT)
+                        .role(MEMBER)
+                        .addressCode(addressCode)
+                        .address(address)
+                        .addressDetail(addressDetail)
+                        .build());
     }
 
     /**

--- a/src/main/java/com/domo/ecommerce/service/MemberService.java
+++ b/src/main/java/com/domo/ecommerce/service/MemberService.java
@@ -34,18 +34,8 @@ public class MemberService {
         isDuplicatedMemberId(memberId);
 
         memberRepository.save(
-                Member.builder()
-                        .memberId(memberId)
-                        .password(SHA256Util.encryptSHA256(password))
-                        .name(name)
-                        .tel(tel)
-                        .addressCode(addressCode)
-                        .address(address)
-                        .addressDetail(addressDetail)
-                        .status(DEFAULT)
-                        .role(MEMBER)
-                        .build()
-        );
+                new Member(null, memberId, SHA256Util.encryptSHA256(password), name,
+                        tel, DEFAULT, MEMBER, addressCode, address, addressDetail));
     }
 
     /**

--- a/src/test/java/com/domo/ecommerce/service/MemberServiceTest.java
+++ b/src/test/java/com/domo/ecommerce/service/MemberServiceTest.java
@@ -1,6 +1,9 @@
 package com.domo.ecommerce.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.domo.ecommerce.type.MemberStatus.DEFAULT;
+import static com.domo.ecommerce.type.Role.MEMBER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -100,12 +103,21 @@ class MemberServiceTest {
         String addressCode = "63309";
         String address = "제주특별자치도 제주시";
         String addressDetail = "1층";
-        Member member = Member.signUp(
-                memberId, password, name, tel, addressCode, address, addressDetail
-        );
 
         given(memberRepository.findByMemberIdAndPassword(anyString(), anyString()))
-                .willReturn(Optional.of(member));
+                .willReturn(Optional.of(
+                        Member.builder()
+                                .id(1L)
+                                .memberId(memberId)
+                                .name(name)
+                                .tel(tel)
+                                .addressCode(addressCode)
+                                .address(address)
+                                .addressDetail(addressDetail)
+                                .status(DEFAULT)
+                                .role(MEMBER)
+                                .build()
+                ));
 
         //when
         memberService.login(memberId, password);

--- a/src/test/java/com/domo/ecommerce/service/MemberServiceTest.java
+++ b/src/test/java/com/domo/ecommerce/service/MemberServiceTest.java
@@ -105,9 +105,18 @@ class MemberServiceTest {
         String addressDetail = "1층";
 
         given(memberRepository.findByMemberIdAndPassword(anyString(), anyString()))
-                .willReturn(Optional.of(
-                        new Member(1L, memberId, SHA256Util.encryptSHA256(password), name,
-                                tel, DEFAULT, MEMBER, addressCode, address, addressDetail)));
+                .willReturn(Optional.of(Member.builder()
+                        .id(1L)
+                        .memberId(memberId)
+                        .password(SHA256Util.encryptSHA256(password))
+                        .name(name)
+                        .tel(tel)
+                        .status(DEFAULT)
+                        .role(MEMBER)
+                        .addressCode(addressCode)
+                        .address(address)
+                        .addressDetail(addressDetail)
+                        .build()));
 
         //when
         memberService.login(memberId, password);

--- a/src/test/java/com/domo/ecommerce/service/MemberServiceTest.java
+++ b/src/test/java/com/domo/ecommerce/service/MemberServiceTest.java
@@ -106,18 +106,8 @@ class MemberServiceTest {
 
         given(memberRepository.findByMemberIdAndPassword(anyString(), anyString()))
                 .willReturn(Optional.of(
-                        Member.builder()
-                                .id(1L)
-                                .memberId(memberId)
-                                .name(name)
-                                .tel(tel)
-                                .addressCode(addressCode)
-                                .address(address)
-                                .addressDetail(addressDetail)
-                                .status(DEFAULT)
-                                .role(MEMBER)
-                                .build()
-                ));
+                        new Member(1L, memberId, SHA256Util.encryptSHA256(password), name,
+                                tel, DEFAULT, MEMBER, addressCode, address, addressDetail)));
 
         //when
         memberService.login(memberId, password);


### PR DESCRIPTION



## 관련 이슈 번호
- #10 
## 설명
이전 Member Entity 정의 시 무분별한 Setter 사용으로 인해 객체의 일관성을 보장할 수 없다고 판단되어,
Setter를 만들지 않고 생성자를 protected로 변경 후 정적 팩토리 메소드를 사용하여 객체를 생성했습니다.

그러나, admin 테스트 코드 작성 시 MemberEntity 객체 생성 시 Role에 ADMIN을 넣어줄 수 없는 문제가 있어,

기존과 같이 기본생성자를 protected를 주고, Builder 패턴을 사용하여 객체를 생성하는걸로 결정하였습니다.

하지만, Builder 패턴의 의도인 null이 들어갈 수 있다는 점을 인지해야 될 것 같습니다.
## 변경사항
<!-- PR에 반영되어야 할 변경 사항들을 가능한 자세히 작성 해주세요. -->
<!-- - [x] 회원가입 및 로그인 -->
- [x] Member 객체 생성 시 Role에 ADMIN을 set해주지 못하는 문제로 MemberEntity Builder로 변경 (Builder는 null이 들어갈 수 있음)
- [x] MemberEntity 정적팩토리 메서드 -> Builder로 변경
- [x] BaseEntity Setter 삭제
- [x] BaseEntity @CreateDate, @LastModifiedDate 추가
- [x] BaseEntity isDeleted(boolean) -> deletedAt(LocalDateTime) 변경
- [x] MemberEntity에 @Where, @SQLDelete 추가
## 질문사항
